### PR TITLE
Use HTTPS for PyPI client

### DIFF
--- a/checkmyreqs.py
+++ b/checkmyreqs.py
@@ -29,7 +29,7 @@ except ImportError:
 
 
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
-CLIENT = ServerProxy('http://pypi.python.org/pypi')
+CLIENT = ServerProxy('https://pypi.python.org/pypi')
 
 IGNORED_PREFIXES = ['#', 'git+', 'hg+', 'svn+', 'bzr+', '\n', '\r\n']
 


### PR DESCRIPTION
I got the following error trying to use ``checkmyreqs``:

```
Traceback (most recent call last):
  File "/home/alan/.local/bin/checkmyreqs", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/home/alan/tmp/checkmyreqs/checkmyreqs", line 189, in <module>
    main()
  File "/home/alan/tmp/checkmyreqs/checkmyreqs", line 184, in main
    check_packages(packages, args.python)
  File "/home/alan/tmp/checkmyreqs/checkmyreqs", line 77, in check_packages
    package_info = CLIENT.release_data(package_name, package_version)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1240, in __call__
    return self.__send(self.__name, args)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1599, in __request
    verbose=self.__verbose
  File "/usr/lib/python2.7/xmlrpclib.py", line 1280, in request
    return self.single_request(host, handler, request_body, verbose)
  File "/usr/lib/python2.7/xmlrpclib.py", line 1328, in single_request
    response.msg,
xmlrpclib.ProtocolError: <ProtocolError for pypi.python.org/pypi: 403 Must access using HTTPS instead of HTTP>
```

See https://mail.python.org/pipermail/distutils-sig/2016-June/029125.html for related PyPI announcement.