### PR TITLE
Talk to PyPI over HTTPS, as HTTP support is gone.

### DIFF
--- a/checkmyreqs.py
+++ b/checkmyreqs.py
@@ -29,7 +29,7 @@ except ImportError:
 
 
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
-CLIENT = ServerProxy('http://pypi.python.org/pypi')
+CLIENT = ServerProxy('https://pypi.python.org/pypi')
 
 IGNORED_PREFIXES = ['#', 'git+', 'hg+', 'svn+', 'bzr+', '\n', '\r\n']
 


### PR DESCRIPTION
The tool is currently non-functional because PyPI got rid of HTTP. This is a one-character fix to use HTTPS instead.